### PR TITLE
Make sakusen compile on modern ubuntu

### DIFF
--- a/bindings/perl5/libsakusen/.gitignore
+++ b/bindings/perl5/libsakusen/.gitignore
@@ -6,3 +6,6 @@ Sakusen.o
 Sakusen.pm
 blib
 pm_to_blib
+MYMETA.json
+MYMETA.yml
+Sakusen.h

--- a/fuseki/Makefile.local
+++ b/fuseki/Makefile.local
@@ -5,7 +5,7 @@ SOURCE_DIRS = settingstree
 THIS_LDFLAGS = -no-install
 LIB_DEP_NAMES = optimal sakusen sakusen-comms sakusen-resources \
 								sakusen-server sakusen-server-plugins
-LIBS :=
+LIBS := -lboost_filesystem -lboost_system -lltdl
 
 ifeq ($(ENABLE_LTDL_HACKED),yes)
 LIB_DEP_NAMES += ltdl_hacked

--- a/sakusen/ref.h
+++ b/sakusen/ref.h
@@ -58,7 +58,7 @@ class Ref {
      * \warning If you store a reference obtained via this function, then you
      * risk accessing it after it has been deleted.
      */
-    inline typename boost::shared_ptr<T>::reference operator*() const {
+    inline typename boost::detail::sp_dereference<T>::type operator*() const {
       return *referee.lock();
     }
 

--- a/sakusen/resources/test/Makefile.local
+++ b/sakusen/resources/test/Makefile.local
@@ -1,6 +1,7 @@
 BIN = libsakusen-resources-test
 LIB_DEP_NAMES = sakusen sakusen-comms sakusen-resources
 THIS_LDFLAGS = -no-install
+LIBS := -lboost_filesystem -lboost_system
 
 test-nonrecursive: $(BIN)
 	./$(BIN)

--- a/server-test/Makefile.local
+++ b/server-test/Makefile.local
@@ -1,11 +1,13 @@
 BIN = libsakusen-server-test
-LIBS := -lrt
+LIBS := -lrt -lboost_filesystem -lboost_system
 LIB_DEP_NAMES = sakusen sakusen-server sakusen-comms sakusen-resources
 THIS_CXXFLAGS =
 THIS_LDFLAGS = -no-install
 
 ifeq ($(ENABLE_LTDL_HACKED),yes)
 LIB_DEP_NAMES += ltdl_hacked
+else
+LIBS += -lltdl
 endif
 
 ifeq ($(ENABLE_AVAHI),yes)

--- a/tedomari/Makefile.local
+++ b/tedomari/Makefile.local
@@ -5,7 +5,7 @@ THIS_CXXFLAGS :=
 # tedomari is to be installed
 THIS_LDFLAGS = -no-install
 LIB_DEP_NAMES = sakusen sakusen-comms sakusen-resources sakusen-client optimal
-LIBS :=
+LIBS := -lboost_filesystem -lboost_system
 THIS_CPPFLAGS =
 
 ifeq ($(ENABLE_READLINE),yes)

--- a/tedomari/main.cpp
+++ b/tedomari/main.cpp
@@ -643,9 +643,20 @@ Options getOptions(
 }
 
 UI::Ptr newUI(
-    const Options& o,
-    const boost::filesystem::path& uiConfFilePath,
+    const Options& o
+#ifdef DISABLE_CAIRO
+__attribute__((unused))
+#endif
+,
+    const boost::filesystem::path& uiConfFilePath
+#ifdef DISABLE_CAIRO
+__attribute__((unused))
+#endif
+,
     Game* game
+#ifdef DISABLE_CAIRO
+__attribute__((unused))
+#endif
   )
 {
   /** \todo Support alternate UIs (OpenGL, DirectX) */

--- a/tools/autogenerate-config.sh
+++ b/tools/autogenerate-config.sh
@@ -112,7 +112,7 @@ check_for_pyplusplus
 check_for_prog pyqt4 pykdeuic4
 #check_for_prog something_that_doesnt_exist
 check_for_lib boost boost/shared_ptr.hpp
-check_for_lib boost_filesystem boost/filesystem/path.hpp -lboost_filesystem -lboost_system
+check_for_lib boost_filesystem boost/filesystem/path.hpp -lboost_filesystem -lboost_system -DBOOST_SYSTEM_NO_DEPRECATED
 check_for_lib readline readline/readline.h -lreadline
 check_for_lib SDL SDL/SDL.h -lSDL
 check_for_lib pangocairo pango/pangocairo.h `pkg-config pangocairo --cflags --libs`


### PR DESCRIPTION
* Use `-DBOOST_SYSTEM_NO_DEPRECATED` when detecting boost
* Add boost libraries where required
* Use native libltdl when not using libltdl_hacked
* Change type of shared pointer dereference to match that used in boost
* Mark parameters as unused when UI is disabled