### PR TITLE
C++14 port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ addons:
   apt:
     sources:
       - deadsnakes
-      - ubuntu-toolchain-r-test
-      - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+      - ubuntu-toolchain-r-test # For gcc-6/g++-6
+      - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' # For swig3.0
     packages:
       - gcc-6
       - g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ addons:
     sources:
       - deadsnakes
       - ubuntu-toolchain-r-test
+      - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
     packages:
       - gcc-6
       - g++-6
       - libmhash-dev
       - libboost-all-dev
-      - swig
+      - swig3.0/trusty-backports
       - python-py++
       - tcl-dev
       - libsdl1.2-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,6 @@ addons:
       - kdepim-runtime
       - akonadi-server
       - akonadi-backend-mysql
+      - mysql-server-core-5.5
+      - mysql-client-core-5.5
 script: cp makefiles/config.mk.ubuntu config.mk && make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ addons:
   apt:
     sources:
       - deadsnakes
+      - ubuntu-toolchain-r-test
     packages:
+      - gcc-6
+      - g++-6
       - libmhash-dev
       - libboost-all-dev
       - swig

--- a/INSTALL
+++ b/INSTALL
@@ -55,6 +55,10 @@ If you're going to be building sakusen repeatedly you can save a lot of time by
 adding "BUILD_LIBTOOLFLAGS=--tag=disable-static" to your config.mk.  This will
 mean that only shared versions of library object files are built.
 
+config.mk is for local choices of flags and other variables which should be
+chosen on a per-build-environment basis.  Use build.mk for flags that should be
+the same everywhere and must exist before Makefile.local is processed.
+
 A hacked version of libltdl is provided which gives better error messages than
 the mainline one (it loses some functionality too, but not in cases that matter
 to sakusen).  If you want to use this (because you're developing sakusen game

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ this_srcdir =
 
 all:
 
+include global.mk
+
 # Don't include the config file if we're trying to make it
 ifneq ($(MAKECMDGOALS),config)
 include config.mk
@@ -56,6 +58,7 @@ $(BUILTIN_CONFIG_MAKEFILES): %/Makefile: $(top_srcdir)makefiles/Makefile.common
 	@echo >> $@
 	@echo 'all:' >> $@
 	@echo >> $@
+	@echo 'include $$(top_builddir)global.mk' >> $@
 	@echo 'include $$(top_builddir)config.mk' >> $@
 	@echo 'include ../Makefile.local' >> $@
 	@echo 'include $$(top_srcdir)makefiles/Makefile.common' >> $@

--- a/bindings/perl5/libsakusen/Makefile.PL
+++ b/bindings/perl5/libsakusen/Makefile.PL
@@ -5,14 +5,11 @@ use ExtUtils::MakeMaker;
 my $CC = $ENV{'CXX'} || 'g++';
 my $LD = '$(CC)';
 my $LDDLFLAGS = $ENV{'LDDLFLAGS'} || '';
-#$libtool = 'libtool';
 my $top_srcdir = $ENV{'top_srcdir'} || die;
 my $top_builddir = $ENV{'top_builddir'} || die;
 my $this_srcdir = $ENV{'this_srcdir'} || die;
 
-# note the order of these two assignments
-#$LD = "$libtool --tag=CXX --mode=link $CC -module -avoid-version";
-#$CC = "$libtool --mode=compile --tag=CXX $CC";
+my $dep_lib_dir = $top_builddir.'sakusen/.libs/';
 
 WriteMakefile(
   NAME => 'Sakusen',
@@ -25,7 +22,9 @@ WriteMakefile(
   INC => '-I'.$top_srcdir.' '.$ENV{'BUILD_CPPFLAGS'},
   OBJECT => 'Sakusen.o',
   FIRST_MAKEFILE => 'Makefile.PL.out',
-  LIBS => $top_builddir . 'sakusen/.libs/libsakusen.so',
+  MYEXTLIB => $dep_lib_dir.'libsakusen.so',
   test => { TESTS => $this_srcdir.'t/*.t' },
-  LDDLFLAGS => $LDDLFLAGS.' '.$top_builddir.'sakusen/.libs/libsakusen.so -shared -Wl,--rpath -Wl,'.`cd ../../../sakusen/.libs/ && pwd`,
+  dynamic_lib => {
+    OTHERLDFLAGS => '-Wl,-rpath -Wl,'.`cd $dep_lib_dir && pwd`,
+  },
 );

--- a/bindings/perl5/libsakusen/Makefile.PL
+++ b/bindings/perl5/libsakusen/Makefile.PL
@@ -25,7 +25,6 @@ WriteMakefile(
   INC => '-I'.$top_srcdir.' '.$ENV{'BUILD_CPPFLAGS'},
   OBJECT => 'Sakusen.o',
   FIRST_MAKEFILE => 'Makefile.PL.out',
-  LDLOADLIBS => '../../../sakusen/.libs/libsakusen.so',
   LIBS => $top_builddir . 'sakusen/.libs/libsakusen.so',
   test => { TESTS => $this_srcdir.'t/*.t' },
   LDDLFLAGS => $LDDLFLAGS.' '.$top_builddir.'sakusen/.libs/libsakusen.so -shared -Wl,--rpath -Wl,'.`cd ../../../sakusen/.libs/ && pwd`,

--- a/bindings/perl5/libsakusen/Makefile.local
+++ b/bindings/perl5/libsakusen/Makefile.local
@@ -2,6 +2,7 @@ PERL5 ?= perl
 SWIG ?= swig
 PREFIX ?= /usr/local
 PERL5ARCH := $(shell $(PERL5) -MConfig -e 'print $$Config{archlib}')
+BUILD_CPPFLAGS += -std=c++14
 THIS_CPPFLAGS := -I$(PERL5ARCH)/CORE -I../../../sakusen $(BUILD_CPPFLAGS)
 
 # Ask that Makefile.common not try to do things for us

--- a/bindings/perl5/libsakusen/Makefile.local
+++ b/bindings/perl5/libsakusen/Makefile.local
@@ -35,7 +35,7 @@ clean: Makefile.PL.out
 Makefile.PL: $(this_srcdir)Makefile.PL
 	cp $< $@
 
-Makefile.PL.out: Makefile.PL Sakusen.cpp
+Makefile.PL.out: Makefile.PL Sakusen.cpp Makefile.local
 	top_builddir=$(top_builddir) \
 	top_srcdir=$(top_srcdir) \
 	this_srcdir=$(this_srcdir) \

--- a/bindings/python/libsakusen/Makefile.local
+++ b/bindings/python/libsakusen/Makefile.local
@@ -3,7 +3,7 @@ PREFIX ?= /usr/local
 PYTHON ?= python
 THIS_CPPFLAGS := \
 	$(GLOBAL_CXXPPFLAGS) $(BUILD_CPPFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir) `python3-config --cflags` $(SWIGWORDSIZE)
+	-I$(top_srcdir) -I$(top_srcdir) `python3-config --includes` $(SWIGWORDSIZE)
 define PYTHON_VERSION
 `printf "from __future__ import print_function\nimport distutils.sysconfig\nprint(distutils.sysconfig.get_python_version())\n"| $(PYTHON)`
 endef

--- a/bindings/python/libsakusen/Makefile.local
+++ b/bindings/python/libsakusen/Makefile.local
@@ -3,7 +3,7 @@ PREFIX ?= /usr/local
 PYTHON ?= python
 THIS_CPPFLAGS := \
 	$(GLOBAL_CXXPPFLAGS) $(BUILD_CPPFLAGS) \
-	-I$(top_srcdir) -I$(top_srcdir) `python3-config --includes` $(SWIGWORDSIZE)
+	-I$(top_srcdir) `python3-config --includes` $(SWIGWORDSIZE)
 define PYTHON_VERSION
 `printf "from __future__ import print_function\nimport distutils.sysconfig\nprint(distutils.sysconfig.get_python_version())\n"| $(PYTHON)`
 endef

--- a/bindings/python/libsakusen/Makefile.local
+++ b/bindings/python/libsakusen/Makefile.local
@@ -1,7 +1,9 @@
 SWIG ?= swig
 PREFIX ?= /usr/local
 PYTHON ?= python
-THIS_CPPFLAGS := $(BUILD_CPPFLAGS) -I$(top_srcdir) -I$(top_srcdir) `python3-config --cflags` $(SWIGWORDSIZE)
+THIS_CPPFLAGS := \
+	$(GLOBAL_CXXPPFLAGS) $(BUILD_CPPFLAGS) \
+	-I$(top_srcdir) -I$(top_srcdir) `python3-config --cflags` $(SWIGWORDSIZE)
 define PYTHON_VERSION
 `printf "from __future__ import print_function\nimport distutils.sysconfig\nprint(distutils.sysconfig.get_python_version())\n"| $(PYTHON)`
 endef

--- a/bindings/tcl/libsakusen/Makefile.local
+++ b/bindings/tcl/libsakusen/Makefile.local
@@ -1,6 +1,8 @@
 SWIG ?= swig
 PREFIX ?= /usr/local
-THIS_CPPFLAGS := -I$(top_srcdir) -I/usr/include/tcl
+THIS_CPPFLAGS := \
+	$(GLOBAL_CXXPPFLAGS) $(BUILD_CPPFLAGS) \
+	-I$(top_srcdir) -I/usr/include/tcl
 
 # Ask that Makefile.common not try to do things for us
 NO_AUTO_COMPILING := yes

--- a/fuseki/main.cpp
+++ b/fuseki/main.cpp
@@ -271,12 +271,12 @@ int startServer(const Options& options)
 
     /* Use the default socket address */
     unixSocketAddress =
-      "concrete"SAKUSEN_COMMS_ADDR_DELIM + unixSocketPath.string();
+      "concrete" SAKUSEN_COMMS_ADDR_DELIM + unixSocketPath.string();
   }
 
   cout << "Creating unix socket " << unixSocketAddress << endl;
   Socket::Ptr unixSocket =Socket::newBindingToAddress(
-        "unix"SAKUSEN_COMMS_ADDR_DELIM+unixSocketAddress
+        "unix" SAKUSEN_COMMS_ADDR_DELIM + unixSocketAddress
       );
 
   if (unixSocket == NULL) {
@@ -292,7 +292,8 @@ int startServer(const Options& options)
   if (!bindAddress.empty()) {
     cout << "Starting TCP socket at " << bindAddress << endl;
     tcpSocket =
-      Socket::newBindingToAddress("tcp"SAKUSEN_COMMS_ADDR_DELIM+bindAddress);
+      Socket::newBindingToAddress(
+        "tcp" SAKUSEN_COMMS_ADDR_DELIM + bindAddress);
 
     if (tcpSocket==NULL) {
       cout << "Error creating TCP socket at:" << endl;

--- a/global.mk
+++ b/global.mk
@@ -4,7 +4,7 @@
 # apply to a build or a binary respectively).
 GLOBAL_CXXFLAGS ?= \
 	-Werror -Wall -Wextra -Woverloaded-virtual -Wundef -Wpointer-arith \
-	-Wwrite-strings -O0 -g3
+	-Wwrite-strings -Wno-deprecated-declarations -O0 -g3
 GLOBAL_CFLAGS ?= -Werror -O0 -g3
 GLOBAL_CXXPPFLAGS ?= -std=c++14
 

--- a/global.mk
+++ b/global.mk
@@ -1,0 +1,10 @@
+# Add warnings and debugging, and turn off optimizations.  To get optimizations
+# and such things, they should be added to BUILD_CXXFLAGS in a config.mk or to
+# THIS_CXXFLAGS in a Makefile.local (depending on whether they are supposed to
+# apply to a build or a binary respectively).
+GLOBAL_CXXFLAGS ?= \
+	-Werror -Wall -Wextra -Woverloaded-virtual -Wundef -Wpointer-arith \
+	-Wwrite-strings -O0 -g3
+GLOBAL_CFLAGS ?= -Werror -O0 -g3
+GLOBAL_CXXPPFLAGS ?= -std=c++14
+

--- a/makefiles/Makefile.common
+++ b/makefiles/Makefile.common
@@ -116,13 +116,6 @@ MAKEFRAGS := \
 		.makefrags/$(subst ..,_dot_dot,$(source)).makefrag\
 	)
 
-# Add warnings and debugging, and turn off optimizations.  To get optimizations
-# and such things, they should be added to BUILD_CXXFLAGS in a config.mk or to
-# THIS_CXXFLAGS in a Makefile.local (depending on whether they are supposed to
-# apply to a build or a binary respectively).
-GLOBAL_CXXFLAGS ?= -Werror -Wall -Wextra -Woverloaded-virtual -Wundef -Wpointer-arith -Wwrite-strings -O0 -g3
-GLOBAL_CFLAGS ?= -Werror -O0 -g3
-
 # We replace '-' with '/' in the library name when using it as a directory
 # because e.g. libsakusen-comms is in libsakusen/comms
 
@@ -131,11 +124,12 @@ LIB_DEP := $(foreach lib,$(LIB_DEP_NAMES), \
 	)
 ALL_CPPFLAGS := $(CPPFLAGS) $(BUILD_CPPFLAGS) -I$(this_srcdir) \
 	-I$(top_builddir) -I$(top_srcdir) $(THIS_CPPFLAGS)
+ALL_CXXPPFLAGS := $(ALL_CPPFLAGS) $(GLOBAL_CXXPPFLAGS)
 
 # Concatenate all the CXXFLAGSs and CFLAGSs together
 
 ALL_CXXFLAGS := \
-	$(CXXFLAGS) $(GLOBAL_CXXFLAGS) $(BUILD_CXXFLAGS) $(ALL_CPPFLAGS) $(THIS_CXXFLAGS)
+	$(CXXFLAGS) $(GLOBAL_CXXFLAGS) $(BUILD_CXXFLAGS) $(ALL_CXXPPFLAGS) $(THIS_CXXFLAGS)
 ALL_CFLAGS := \
 	$(CFLAGS) $(GLOBAL_CFLAGS) $(BUILD_CFLAGS) $(ALL_CPPFLAGS) $(THIS_CFLAGS)
 ALL_LIBTOOLFLAGS := $(BUILD_LIBTOOLFLAGS)
@@ -171,6 +165,7 @@ $(SUBDIR_MAKEFILES): %/Makefile: $(top_srcdir)makefiles/Makefile.common
 	@echo >> $@
 	@echo 'all:' >> $@
 	@echo >> $@
+	@echo 'include $$(top_builddir)global.mk' >> $@
 	@echo 'include $$(top_builddir)config.mk' >> $@
 	@echo 'ifneq (,$$(wildcard Makefile.local))' >> $@
 	@echo '  include Makefile.local' >> $@
@@ -342,7 +337,7 @@ endif
 
 $(MAKEFRAGS): .makefrags/%.makefrag: $(top_srcdir)makefiles/Makefile.common
 	@mkdir -p $(dir $@)
-	$(CPP) $(ALL_CPPFLAGS) -MT .obj/$(basename $*).$(MAKEFRAG_DEP_EXTENSION) \
+	$(CPP) $(ALL_CXXPPFLAGS) -MT .obj/$(basename $*).$(MAKEFRAG_DEP_EXTENSION) \
 		-MT $@ -MP -M -MF $@ $(this_srcdir)$(subst _dot_dot,..,$*)
 	printf "\n%s:\n" "$(this_srcdir)$(subst _dot_dot,..,$*)" >> $@
 

--- a/makefiles/config.mk.ubuntu
+++ b/makefiles/config.mk.ubuntu
@@ -74,3 +74,4 @@ BUILD_ARCH := x86_64
 BUILD_LIBTOOLFLAGS = --tag=disable-static
 CC = gcc-6
 CXX = g++-6
+SWIG = swig3.0

--- a/makefiles/config.mk.ubuntu
+++ b/makefiles/config.mk.ubuntu
@@ -71,3 +71,5 @@ ifeq ($(ENABLE_UNIVERSE_BUILDER),no)
 endif
 
 BUILD_ARCH := x86_64
+CC = gcc-6
+CXX = g++-6

--- a/makefiles/config.mk.ubuntu
+++ b/makefiles/config.mk.ubuntu
@@ -71,5 +71,6 @@ ifeq ($(ENABLE_UNIVERSE_BUILDER),no)
 endif
 
 BUILD_ARCH := x86_64
+BUILD_LIBTOOLFLAGS = --tag=disable-static
 CC = gcc-6
 CXX = g++-6

--- a/sakusen/comms/message.h
+++ b/sakusen/comms/message.h
@@ -42,7 +42,7 @@ class LIBSAKUSEN_COMMS_API Message {
       return ( data ? data->getType() : messageType_none );
     }
     inline bool isRealMessage(void) const {
-      return data;
+      return !!data;
     }
     inline const Buffer& getBuffer(void) const {
       return data->getBuffer();

--- a/sakusen/comms/unixdatagramsocket.cpp
+++ b/sakusen/comms/unixdatagramsocket.cpp
@@ -238,11 +238,11 @@ void UnixDatagramSocket::setNonBlocking(bool val)
 String UnixDatagramSocket::getAddress() const {
   if (abstract) {
     return String(
-        "unix"SAKUSEN_COMMS_ADDR_DELIM"abstract"SAKUSEN_COMMS_ADDR_DELIM
+        "unix" SAKUSEN_COMMS_ADDR_DELIM "abstract" SAKUSEN_COMMS_ADDR_DELIM
       ) + (path+1);
   } else {
     return String(
-        "unix"SAKUSEN_COMMS_ADDR_DELIM"concrete"SAKUSEN_COMMS_ADDR_DELIM
+        "unix" SAKUSEN_COMMS_ADDR_DELIM "concrete" SAKUSEN_COMMS_ADDR_DELIM
       ) + path;
   }
 }

--- a/sakusen/heightfield.cpp
+++ b/sakusen/heightfield.cpp
@@ -3,8 +3,7 @@
 #include <sakusen/oarchive-methods.h>
 #include <sakusen/mathsutils.h>
 
-using namespace std;
-using namespace sakusen;
+namespace sakusen {
 
 Heightfield::Heightfield(
     uint32 xyR,
@@ -93,15 +92,15 @@ void Heightfield::sanityCheck() const
   if (width == 0 || height == 0) {
     SAKUSEN_FATAL("heightfield dimension 0");
   }
-  if (numeric_limits<uint32>::max() / width < height) {
+  if (std::numeric_limits<uint32>::max() / width < height) {
     SAKUSEN_FATAL("heightfield contains too much data");
   }
   /* Check that all possible height values fit into the proper range */
   if (zResolution == 0 || xyResolution == 0) {
     SAKUSEN_FATAL("heightfield resolution 0");
   }
-  if (numeric_limits<sint32>::max() / zResolution <
-      uint32(numeric_limits<sint16>::max())) {
+  if (std::numeric_limits<sint32>::max() / zResolution <
+      uint32(std::numeric_limits<sint16>::max())) {
     SAKUSEN_FATAL(
         "heights could overflow (zres is " << zResolution <<
         ")"
@@ -264,7 +263,7 @@ sint32 Heightfield::getMaxHeightIn(const Rectangle<sint32>& area) const
     SAKUSEN_FATAL("rectangle outside map");
   }
   Rectangle<sint32> croppedArea = area.intersect(world->getMap()->area());
-  sint32 result = numeric_limits<sint32>::min();
+  sint32 result = std::numeric_limits<sint32>::min();
   /* We check the height at various positions, exploiting the fact that we know
    * the height is linearly interpolated between samples.
    *
@@ -276,29 +275,34 @@ sint32 Heightfield::getMaxHeightIn(const Rectangle<sint32>& area) const
   uint32 maxSampleX = dexToSampleCeilX(croppedArea.getMaxX());
   uint32 maxSampleY = dexToSampleCeilY(croppedArea.getMaxY());
   /* The corners */
-  result =
-    max(result, getHeightAt(croppedArea.getMinX(), croppedArea.getMinY()));
-  result =
-    max(result, getHeightAt(croppedArea.getMaxX(), croppedArea.getMinY()));
-  result =
-    max(result, getHeightAt(croppedArea.getMinX(), croppedArea.getMaxY()));
-  result =
-    max(result, getHeightAt(croppedArea.getMaxX(), croppedArea.getMaxY()));
+  result = std::max(
+    result, getHeightAt(croppedArea.getMinX(), croppedArea.getMinY()));
+  result = std::max(
+    result, getHeightAt(croppedArea.getMaxX(), croppedArea.getMinY()));
+  result = std::max(
+    result, getHeightAt(croppedArea.getMinX(), croppedArea.getMaxY()));
+  result = std::max(
+    result, getHeightAt(croppedArea.getMaxX(), croppedArea.getMaxY()));
   /* The following edge computations are far from optimized */
   /* Across the top and bottom edges */
   for (uint32 x = minSampleX; x < maxSampleX; ++x) {
-    result = max(result, getHeightAt(sampleToDexX(x), croppedArea.getMinY()));
-    result = max(result, getHeightAt(sampleToDexX(x), croppedArea.getMaxY()));
+    result = std::max(
+      result, getHeightAt(sampleToDexX(x), croppedArea.getMinY()));
+    result = std::max(
+      result, getHeightAt(sampleToDexX(x), croppedArea.getMaxY()));
   }
   /* Up the left and right edges */
   for (uint32 y = minSampleY; y < maxSampleY; ++y) {
-    result = max(result, getHeightAt(croppedArea.getMinX(), sampleToDexY(y)));
-    result = max(result, getHeightAt(croppedArea.getMaxX(), sampleToDexY(y)));
+    result = std::max(
+      result, getHeightAt(croppedArea.getMinX(), sampleToDexY(y)));
+    result = std::max(
+      result, getHeightAt(croppedArea.getMaxX(), sampleToDexY(y)));
   }
   /* The internal points */
   for (uint32 x = minSampleX; x < maxSampleX; ++x) {
     for (uint32 y = minSampleY; y < maxSampleY; ++y) {
-      result = max(result, getHeightAtSample(x, y));
+      result = std::max(
+        result, getHeightAtSample(x, y));
     }
   }
   return result;
@@ -325,7 +329,7 @@ double Heightfield::intersectRay(const Ray& ray, double extent) const
    * A Fast Voxel Traversal Algorithm for Ray Tracing,
    * John Amanatides, Andrew Woo
    */
-  const double inf = numeric_limits<double>::infinity();
+  const double inf = std::numeric_limits<double>::infinity();
 
   if (extent == inf) {
     /* This could well make us loop forever, so abort instead */
@@ -465,3 +469,4 @@ Heightfield Heightfield::load(
   }
 }
 
+}

--- a/sakusen/heightfield.cpp
+++ b/sakusen/heightfield.cpp
@@ -162,7 +162,7 @@ double Heightfield::intersectRayInCell(
 
   boost::tie(r1, r2) = mathsUtils_solveQuadratic(a, b, c);
 
-  if (isnan(r1) || (!isnan(r2) && r2 < minimum)) {
+  if (std::isnan(r1) || (!std::isnan(r2) && r2 < minimum)) {
     /* Something's gone wrong... */
     SAKUSEN_FATAL("no valid solution found");
   }
@@ -174,7 +174,7 @@ double Heightfield::intersectRayInCell(
       return std::numeric_limits<double>::infinity();
     }
   } else {
-    if (!isnan(r2) && r2 <= extent) {
+    if (!std::isnan(r2) && r2 <= extent) {
       return r2;
     } else {
       return std::numeric_limits<double>::infinity();

--- a/sakusen/orientation.cpp
+++ b/sakusen/orientation.cpp
@@ -175,7 +175,7 @@ void Orientation::sanityCheck() const
 {
   for (int i=0; i<3; ++i) {
     for (int j=0; j<3; ++j) {
-      assert(!isnan(matrix[i][j]));
+      assert(!std::isnan(matrix[i][j]));
       assert(matrix[i][j] >= -1);
       assert(matrix[i][j] <= 1);
     }

--- a/sakusen/point.h
+++ b/sakusen/point.h
@@ -8,6 +8,36 @@
 
 namespace sakusen {
 
+/* Apparently MSVC is on the ball in this case, but because it has reduced the
+ * answer to a constant, generates a warning (4101) about the now unreferenced local variable.
+ * This is slightly mystifying for a few seconds, and clutters things up, so I have disabled
+ * it.
+ * 4146 is a warning telling me that when I apply a unary minus to an unsigned operator,
+ * nothing happens. Thanks MSVC.
+ */
+#ifdef _MSC_VER
+  #pragma warning (disable:4101 4146)
+#endif
+
+template<typename T>
+inline T bottomNumberImpl(std::true_type) {
+  return std::numeric_limits<T>::min();
+}
+
+template<typename T>
+inline T bottomNumberImpl(std::false_type) {
+  std::numeric_limits<T> limits;
+
+  if (limits.is_signed) {
+    if (limits.has_infinity)
+      return -(limits.infinity());
+    else
+      return -(limits.max());
+  } else
+    return static_cast<T>(0);
+}
+
+
 /** \brief Get the most negative number.
  * \return The minimal number of type T
  *
@@ -21,31 +51,9 @@ namespace sakusen {
  * representable number not equal to the negation of the most +ve
  * representable number. So sue me.
  */
-
-/* Apparently MSVC is on the ball in this case, but because it has reduced the
- * answer to a constant, generates a warning (4101) about the now unreferenced local variable.
- * This is slightly mystifying for a few seconds, and clutters things up, so I have disabled
- * it.
- * 4146 is a warning telling me that when I apply a unary minus to an unsigned operator,
- * nothing happens. Thanks MSVC.
- */
-#ifdef _MSC_VER
-  #pragma warning (disable:4101 4146)
-#endif
-
 template<typename T>
 inline T bottomNumber() {
-  std::numeric_limits<T> limits;
-
-  if (limits.is_integer)
-    return limits.min();
-  if (limits.is_signed) {
-    if (limits.has_infinity)
-      return -(limits.infinity());
-    else
-      return -(limits.max());
-  } else
-    return static_cast<T>(0);
+  return bottomNumberImpl<T>(typename std::is_integral<T>::type());
 }
 
 /** \brief Get the most positive number.

--- a/sakusen/point.h
+++ b/sakusen/point.h
@@ -2,6 +2,7 @@
 #define LIBSAKUSEN__POINT_H
 
 #include <sakusen/global.h>
+#include <type_traits>
 #include <boost/utility.hpp>
 
 #include <sakusen/arithmetictraits.h>

--- a/sakusen/ref.h
+++ b/sakusen/ref.h
@@ -58,7 +58,7 @@ class Ref {
      * \warning If you store a reference obtained via this function, then you
      * risk accessing it after it has been deleted.
      */
-    inline typename boost::detail::sp_dereference<T>::type operator*() const {
+    inline std::add_lvalue_reference_t<T> operator*() const {
       return *referee.lock();
     }
 

--- a/sakusen/server/weapon.cpp
+++ b/sakusen/server/weapon.cpp
@@ -71,7 +71,7 @@ bool Weapon::aim(
   boost::tie(tanTheta, boost::tuples::ignore) =
     mathsUtils_solveQuadratic(a, b, c);
 
-  if (isnan(tanTheta)) {
+  if (std::isnan(tanTheta)) {
     return false;
   }
 

--- a/sakusen/sphereregion.h
+++ b/sakusen/sphereregion.h
@@ -152,7 +152,7 @@ inline boost::tuple<double,double> SphereRegion<T>::intersect(
   double c = static_cast<double>(relativeOrigin.squareLength());
 
   boost::tuple<double,double> result = mathsUtils_solveQuadratic(a, b, c);
-  if (isnan(result.get<0>())) {
+  if (std::isnan(result.get<0>())) {
     result.get<0>() = result.get<1>() = std::numeric_limits<double>::infinity();
   }
   return result;

--- a/tedomari/main.cpp
+++ b/tedomari/main.cpp
@@ -263,7 +263,7 @@ void runClient(
 #else
     /* Use default socket */
     socketAddress =
-      "unix"SAKUSEN_COMMS_ADDR_DELIM"concrete"SAKUSEN_COMMS_ADDR_DELIM +
+      "unix" SAKUSEN_COMMS_ADDR_DELIM "concrete" SAKUSEN_COMMS_ADDR_DELIM +
       (fileUtils_configDirectory() / SAKUSEN_COMMS_SOCKET_SUBDIR /
         "fuseki-socket").string();
 #endif

--- a/tools/universe-builder/Makefile.local
+++ b/tools/universe-builder/Makefile.local
@@ -1,5 +1,5 @@
 BIN := universe-builder
-THIS_CPPFLAGS := `pkg-config --cflags libglademm-2.4`
+THIS_CPPFLAGS := `pkg-config --cflags libglademm-2.4 | sed 's/-I/-isystem/g'`
 THIS_LDFLAGS := -export-dynamic -no-install
 LIBS := `pkg-config --libs libglademm-2.4` -lboost_filesystem -lboost_system
 LIB_DEP_NAMES := sakusen sakusen-comms sakusen-resources


### PR DESCRIPTION
Porting to C++14 because the dependent libraries no longer work in C++03 on my system.  Entailed a variety of small changes, due to e.g. nuances in what gets included by which headers, new compile flags, and syntax changes in the new C++.